### PR TITLE
Fix/issue 64

### DIFF
--- a/lib/view/screen/album_page.dart
+++ b/lib/view/screen/album_page.dart
@@ -13,7 +13,6 @@ import 'package:inbear_app/status.dart';
 import 'package:inbear_app/view/screen/base_page.dart';
 import 'package:inbear_app/view/widget/centering_error_message.dart';
 import 'package:inbear_app/view/widget/default_dialog.dart';
-import 'package:inbear_app/view/widget/loading.dart';
 import 'package:inbear_app/view/widget/photo_item.dart';
 import 'package:inbear_app/view/widget/reload_button.dart';
 import 'package:inbear_app/viewmodel/album_viewmodel.dart';
@@ -86,7 +85,7 @@ class AlbumGridView extends StatelessWidget {
         builder: (context, snapshot) {
           switch (snapshot.connectionState) {
             case ConnectionState.waiting:
-              return Center(child: Loading());
+              return Container();
             default:
               if (snapshot.hasError) {
                 if (snapshot.error is TimeoutException) {

--- a/lib/view/screen/album_page.dart
+++ b/lib/view/screen/album_page.dart
@@ -19,9 +19,16 @@ import 'package:inbear_app/view/widget/reload_button.dart';
 import 'package:inbear_app/viewmodel/album_viewmodel.dart';
 import 'package:provider/provider.dart';
 
-class AlbumPage extends StatelessWidget {
+class AlbumPage extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => AlbumPageState();
+}
+
+class AlbumPageState extends State<AlbumPage>
+    with AutomaticKeepAliveClientMixin {
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return BasePage(
       viewModel: AlbumViewModel(
         Provider.of<UserRepository>(context, listen: false),
@@ -31,6 +38,9 @@ class AlbumPage extends StatelessWidget {
       child: AlbumPageContent(),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }
 
 class AlbumPageContent extends StatelessWidget {

--- a/lib/view/screen/base_page.dart
+++ b/lib/view/screen/base_page.dart
@@ -49,7 +49,7 @@ class OverlayLoading<T extends BaseViewModel> extends StatelessWidget {
     return Selector<T, Status>(
       selector: (context, viewModel) => viewModel.status,
       builder: (context, status, child) {
-        debugPrint('Status: $status');
+        debugPrint('Status<${T.toString()}>: $status');
         switch (status) {
           case Status.loading:
             return Container(

--- a/lib/view/screen/home_page.dart
+++ b/lib/view/screen/home_page.dart
@@ -13,7 +13,6 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BasePage<HomeViewModel>(
       viewModel: HomeViewModel(),
-      // FIXME:SafeAreaで囲むとAndroidでStatusBarが黒くなるので一時的にSafeArea解除、Stackが原因か！？
       child: Scaffold(
         appBar: AppBar(
           centerTitle: true,
@@ -48,10 +47,11 @@ class HomePageBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Selector<HomeViewModel, int>(
-      selector: (context, viewModel) => viewModel.selectIndex,
-      builder: (context, index, child) =>
-          IndexedStack(index: index, children: _pages),
+    final viewModel = Provider.of<HomeViewModel>(context, listen: false);
+    return PageView(
+      controller: viewModel.pageController,
+      onPageChanged: (index) => viewModel.updateIndex(index),
+      children: _pages,
     );
   }
 }
@@ -77,7 +77,7 @@ class HomePageBottomNavigationBar extends StatelessWidget {
               BottomNavigationBarItem(
                   icon: Icon(Icons.settings), title: Text('設定'))
             ],
-            onTap: (index) => viewModel.updateIndex(index));
+            onTap: (index) => viewModel.jumpToPage(index));
       },
     );
   }

--- a/lib/view/screen/participant_list_page.dart
+++ b/lib/view/screen/participant_list_page.dart
@@ -16,9 +16,16 @@ import 'package:inbear_app/view/widget/reload_button.dart';
 import 'package:inbear_app/viewmodel/participant_list_viewmodel.dart';
 import 'package:provider/provider.dart';
 
-class ParticipantListPage extends StatelessWidget {
+class ParticipantListPage extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => ParticipantListPageState();
+}
+
+class ParticipantListPageState extends State<ParticipantListPage>
+    with AutomaticKeepAliveClientMixin {
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return BasePage<ParticipantListViewModel>(
       viewModel: ParticipantListViewModel(
           Provider.of<UserRepository>(context, listen: false),
@@ -29,6 +36,9 @@ class ParticipantListPage extends StatelessWidget {
       ),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }
 
 class ParticipantListPageBody extends StatelessWidget {

--- a/lib/view/screen/schedule_page.dart
+++ b/lib/view/screen/schedule_page.dart
@@ -15,9 +15,16 @@ import 'package:provider/provider.dart';
 
 import '../../routes.dart';
 
-class SchedulePage extends StatelessWidget {
+class SchedulePage extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => SchedulePageState();
+}
+
+class SchedulePageState extends State<SchedulePage>
+    with AutomaticKeepAliveClientMixin {
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return BasePage<ScheduleViewModel>(
       viewModel: ScheduleViewModel(
           Provider.of<UserRepository>(context, listen: false),
@@ -28,6 +35,9 @@ class SchedulePage extends StatelessWidget {
       ),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }
 
 class SchedulePageBody extends StatelessWidget {

--- a/lib/view/screen/setting_page.dart
+++ b/lib/view/screen/setting_page.dart
@@ -10,9 +10,16 @@ import 'package:provider/provider.dart';
 
 import '../../routes.dart';
 
-class SettingPage extends StatelessWidget {
+class SettingPage extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => SettingPageState();
+}
+
+class SettingPageState extends State<SettingPage>
+    with AutomaticKeepAliveClientMixin {
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return BasePage<SettingViewModel>(
       viewModel:
           SettingViewModel(Provider.of<UserRepository>(context, listen: false)),
@@ -20,6 +27,9 @@ class SettingPage extends StatelessWidget {
       child: SettingPageContent(),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }
 
 class SettingPageContent extends StatelessWidget {

--- a/lib/viewmodel/home_viewmodel.dart
+++ b/lib/viewmodel/home_viewmodel.dart
@@ -1,7 +1,14 @@
+import 'package:flutter/cupertino.dart';
 import 'package:inbear_app/viewmodel/base_viewmodel.dart';
 
 class HomeViewModel extends BaseViewModel {
+  final PageController pageController = PageController();
+
   int selectIndex = 0;
+
+  void jumpToPage(int index) {
+    pageController.jumpToPage(index);
+  }
 
   void updateIndex(int index) {
     selectIndex = index;


### PR DESCRIPTION
close #64 

### 原因
アルバム画面で StreamBuilder の接続中の状態の時もローディングが起動していたため、二重になっていた。

### 解決法
StreamBuilder の接続中は Container を返すよう修正  
また、IndexedStack だと最初に全ての画面が読み込まれてしまうので、AutomaticKeepAliveClientMixin と PageView を使用することで初めて画面を表示するときにデータを取得するよう修正した。